### PR TITLE
Add blue powerup with triangle shooting

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,8 +107,11 @@ def run_game(screen, clock):
         # Check for powerup collection
         for powerup in powerups:
             if powerup.collides_with(player):
-                # Activate powerup
-                player.powerup_timer = POWERUP_DURATION
+                # Activate the appropriate powerup
+                if getattr(powerup, "color", "yellow") == "blue":
+                    player.blue_powerup_timer = POWERUP_DURATION
+                else:
+                    player.powerup_timer = POWERUP_DURATION
                 powerup.kill()  # Remove the powerup
         
         # Check collisions between bullets and asteroids
@@ -138,6 +141,14 @@ def run_game(screen, clock):
             stream_text = font.render("STREAM MODE ACTIVE!", True, "yellow")
             stream_rect = stream_text.get_rect(midtop=(SCREEN_WIDTH / 2, 50))
             screen.blit(stream_text, stream_rect)
+
+        if player.blue_powerup_timer > 0:
+            timer_text = font.render(f"POWERUP: {int(player.blue_powerup_timer)}", True, "blue")
+            timer_rect = timer_text.get_rect(midtop=(SCREEN_WIDTH / 2, 80))
+            screen.blit(timer_text, timer_rect)
+            stream_text = font.render("TRIANGLE SHOT ACTIVE!", True, "blue")
+            stream_rect = stream_text.get_rect(midtop=(SCREEN_WIDTH / 2, 110))
+            screen.blit(stream_text, stream_rect)
         
         pygame.display.flip()
 
@@ -159,8 +170,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()    
-
-
-if __name__ == "__main__":
     main()
+
+

--- a/powerup.py
+++ b/powerup.py
@@ -5,8 +5,9 @@ from constants import *
 
 
 class PowerUp(CircleShape):
-    def __init__(self, x, y):
+    def __init__(self, x, y, color="yellow"):
         super().__init__(x, y, POWERUP_RADIUS)
+        self.color = color
         # Set random velocity for the powerup
         self.velocity = pygame.Vector2(
             random.uniform(-1, 1),
@@ -14,8 +15,8 @@ class PowerUp(CircleShape):
         ).normalize() * POWERUP_SPEED
     
     def draw(self, screen):
-        # Draw the powerup as a yellow circle with a star-like shape
-        pygame.draw.circle(screen, "yellow", self.position, self.radius, 0)
+        # Draw the powerup using its color
+        pygame.draw.circle(screen, self.color, self.position, self.radius, 0)
         pygame.draw.circle(screen, "white", self.position, self.radius, 2)
     
     def update(self, dt):
@@ -31,3 +32,4 @@ class PowerUp(CircleShape):
         # Keep the powerup within the screen bounds
         self.position.x = max(self.radius, min(SCREEN_WIDTH - self.radius, self.position.x))
         self.position.y = max(self.radius, min(SCREEN_HEIGHT - self.radius, self.position.y))
+

--- a/powerupspawner.py
+++ b/powerupspawner.py
@@ -18,4 +18,7 @@ class PowerUpSpawner(pygame.sprite.Sprite):
             x = random.uniform(padding, SCREEN_WIDTH - padding)
             y = random.uniform(padding, SCREEN_HEIGHT - padding)
             
-            PowerUp(x, y)  # The PowerUp will add itself to the containers
+            # Randomly choose a powerup color (yellow or blue)
+            color = random.choice(["yellow", "blue"])
+            PowerUp(x, y, color=color)  # The PowerUp will add itself to the containers
+


### PR DESCRIPTION
## Summary
- allow powerup color choice and draw by color
- spawn yellow or blue powerups
- track blue powerup timer on the player
- update shooting to fire from all vertices when blue powerup active
- display timers for both yellow and blue powerups

## Testing
- `python -m py_compile main.py player.py powerup.py powerupspawner.py shot.py asteroid.py asteroidfield.py explosion.py constants.py menu_animation.py circleshape.py`